### PR TITLE
Change use of Text to ByteString

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,8 +18,8 @@ library:
   - mtl >=2.2 && <2.3
   - syb >=0.6 && <0.7
   - syz ==0.2.0.0
-  - text >=1.2.2 && <2
   - transformers >=0.5 && <0.6
+  - bytestring
 
 tests:
   spec:
@@ -29,4 +29,4 @@ tests:
     - hspec
     - mtl
     - reprinter
-    - text
+    - bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ library:
   - Text.Reprinter
   dependencies:
   - mtl >=2.2 && <2.3
-  - syb >=0.6 && <0.7
+  - syb >=0.6 && <1.0
   - syz ==0.2.0.0
   - transformers >=0.5 && <0.6
   - bytestring

--- a/reprinter.cabal
+++ b/reprinter.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0ad0da2c1b208227c4f1fecc6abcad0b16d6684288b72053863c91d7f9af74bc
+-- hash: 9e6e81b2f37a1729eb4f9fdecae77790ac4c3b43656bccec7974e1986631a0a2
 
 name:           reprinter
 version:        0.2.0.0
@@ -29,7 +29,7 @@ library
       base >=4.9 && <5
     , bytestring
     , mtl >=2.2 && <2.3
-    , syb >=0.6 && <0.7
+    , syb >=0.6 && <1.0
     , syz ==0.2.0.0
     , transformers >=0.5 && <0.6
   exposed-modules:

--- a/reprinter.cabal
+++ b/reprinter.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a7ba1330bf62df24af407f4fd2d204af695ad460b3bb38dd68b87c8612d22806
+-- hash: 0ad0da2c1b208227c4f1fecc6abcad0b16d6684288b72053863c91d7f9af74bc
 
 name:           reprinter
 version:        0.2.0.0
@@ -15,7 +17,6 @@ author:         Dominic Orchard, Vilem-Benjamin Liepelt, Harry Clarke
 maintainer:     d.a.orchard@kent.ac.uk
 license:        Apache-2.0
 build-type:     Simple
-cabal-version:  >= 1.10
 
 source-repository head
   type: git
@@ -26,16 +27,14 @@ library
       src
   build-depends:
       base >=4.9 && <5
+    , bytestring
     , mtl >=2.2 && <2.3
     , syb >=0.6 && <0.7
     , syz ==0.2.0.0
-    , text >=1.2.2 && <2
     , transformers >=0.5 && <0.6
   exposed-modules:
       Text.Reprinter
   other-modules:
-      Text.Reprinter.Examples.Simple
-      Text.Reprinter.Examples.WeakSourceCoherence
       Paths_reprinter
   default-language: Haskell2010
 
@@ -46,12 +45,11 @@ test-suite spec
       tests/hspec
   build-depends:
       base >=4.9 && <5
+    , bytestring
     , hspec
     , mtl
     , reprinter
-    , text
   other-modules:
       ReprinterSpec
-      ReprinterWeakSpec
       Paths_reprinter
   default-language: Haskell2010

--- a/tests/hspec/ReprinterSpec.hs
+++ b/tests/hspec/ReprinterSpec.hs
@@ -5,7 +5,7 @@
 module ReprinterSpec where
 
 import Control.Monad.State
-import qualified Data.Text.Lazy as Text
+import qualified Data.ByteString.Char8 as BC
 import Data.Char
 import Data.Monoid ((<>))
 import Text.Reprinter
@@ -44,7 +44,7 @@ input_simple = "x  = +(1,0)\n"
 -- We then run this through a parser to get an AST, transform the AST,
 -- and run this through the reprinter to get:
 
-test = putStrLn . Text.unpack . refactor
+test = putStrLn . BC.unpack . refactor
 
 
 type AST = [Decl]
@@ -91,8 +91,8 @@ exprReprinter = catchAll `extQ` reprintExpr
 -- Expressions can be pretty-printed as
 prettyExpr :: Expr -> Source
 prettyExpr (Plus _ _ e1 e2) = "+(" <> prettyExpr e1 <> ", " <> prettyExpr e2 <> ")"
-prettyExpr (Var _ _ n)      = Text.pack n
-prettyExpr (Const _ _ n)    = Text.pack $ show n
+prettyExpr (Var _ _ n)      = BC.pack n
+prettyExpr (Const _ _ n)    = BC.pack $ show n
 
 -- Note we are *not* defining a pretty printer for declarations
 -- as we are never going to need to regenerate these
@@ -144,7 +144,7 @@ commentPrinter = catchAll `extQ` decl
       Just val -> do
         modify ((v,val) :)
         let msg = " // " ++ v ++ " = " ++ show val
-        return (Just (After, Text.pack msg, s))
+        return (Just (After, BC.pack msg, s))
 
 refactor2 :: Source -> Source
 refactor2 input =
@@ -153,7 +153,7 @@ refactor2 input =
   .  parse
   ) input
 
-test2 = putStrLn . Text.unpack . refactor2
+test2 = putStrLn . BC.unpack . refactor2
 
 
 
@@ -168,7 +168,7 @@ test2 = putStrLn . Text.unpack . refactor2
 -- satisfies the WELL-FORMEDNESS-CONDITION for ASTs representing source text
 
 parse :: Source -> AST
-parse s = evalState parseDecl (Text.unpack s, initPosition)
+parse s = evalState parseDecl (BC.unpack s, initPosition)
 
 type Parser = State (String, Position)
 


### PR DESCRIPTION
This library seems to have diverged from the implementation of other camfort projects, which now use `ByteString`. In order to do refactors with the fortran-src AST I think it makes sense to change it to `ByteString` here.

@dorchard 

edit: also loosened the syb restriction as it does work with the current version (0.7.1), and we should expect it to work until the next major version.