### PR TITLE
Splicer and context reprinting

### DIFF
--- a/tests/hspec/ReprinterSpec.hs
+++ b/tests/hspec/ReprinterSpec.hs
@@ -4,6 +4,7 @@
 
 module ReprinterSpec where
 
+import Control.Monad.State
 import Text.Reprinter
 import Text.Reprinter.Example
 
@@ -37,8 +38,17 @@ spec = do
     it "appends evaluated variables in comments" $ do
       refactorComment input_simple `shouldBe` "x  = +(1,0) // x = 1\n"
 
+  describe "splicer" $ do
+    it "50 column line limit" $ do
+      refactorSplicer input_long
+        `shouldBe` "x = +(+(long_name_one, 0)\\\n\
+                   \    , long_name_two)\n"
+
 input_simple :: String
 input_simple = "x  = +(1,0)\n"
+
+input_long :: String
+input_long = "x = +(long_name_one, long_name_two)\n"
 
 type AST' = AST Bool
 
@@ -51,3 +61,39 @@ refactorLoop :: (AST' -> AST') -> AST' -> AST'
 refactorLoop refactoring ast
   | refactoring ast == ast = ast
   | otherwise              = refactorLoop refactoring (refactoring ast)
+
+-- We then run this through a parser to get an AST, transform the AST,
+-- and run this through the reprinter to get:
+refactorSplicer :: String -> String
+refactorSplicer input =
+  ( flip evalState                            initPosition
+    . flip (reprint exprReprinter $ splicer 30) input
+    . addZero
+    . parse
+    )
+    input
+
+-- This is pointless but it demonstrates the splicer by taking lines over a limit
+addZero :: AST' -> AST'
+addZero = map (\(Decl b s n e) -> (Decl b s n (go e)))
+ where
+  go (Var u sp var   ) = Plus True sp (Var u sp var) (Const u sp 0)
+  go (Plus u sp e1 e2) = Plus u sp (go e1) e2
+  go e                 = e
+
+-- Splicer that makes anything over 50 a newline
+splicer :: Int -> String -> State Position String
+splicer n source = do
+  let (pre, post) = span (/= '\n') source
+      preLen      = length pre
+      postLen     = length . takeWhile (/= '\n') . reverse $ post
+      nl          = "\\\n    "
+  (Line x, Col y) <- get
+  res             <- if y + preLen <= n
+    then pre <$ put (Line x, Col $ preLen + y)
+    else nl <> pre <$ put (Line $ x + 1, Col 4)
+  if postLen == 0
+    then pure $ res <> post
+    else do
+      post' <- splicer n post
+      pure $ res <> post'


### PR DESCRIPTION
Remembered this was mentioned the other week but didn't get round to it, so I've rebased the changes onto current master. Really like the new `Example.lhs` btw, wish it was there when I was figuring out the library!

I don't think either of these changes are the best approach (at the very least the `ZipperReprinting` should be optional, or used in a separate reprint function) but fix two issue with the reprinter I encountered while using it. Perhaps a better approach can be use figured out with this in mind.

The splicer part allows a user defined function to be passed in which can perform extra formatting based on the `Reprinting` monad, in my case using a state monad to keep track of the position while we reprint, and then perform necessary line breaks where needed. This was needed because often we'd refactor lines and bring them over the 72 line limit of legacy fortran, causing errors. It kinda hijacks the existing monad, but this seemed like the simplest approach for it to work.

The  `ZipperReprinting` allows for checks of the surrounding context by taking the zipper rather than the node as the argument, which I used to avoid printing more brackets than are necessary. In general I want explicit brackets around logical operators (i.e. `((foo .ne. 0) .and. (bar .ne. 0))`, but I do not want double brackets if something like this is at the top level of a conditional or in a function argument (i.e. neither `if ((foo .ne. 0)) then` or `foo((bar .ne. 0))`).

I think a better solution might be along the lines of having the reprinter also take an AST specific argument which details the context of the section we're reprinting (indentation level, what node it's contained within etc.), and then having the reprinting function itself do formatting based on this, perhaps running on additional unchanged nodes if a line break is needed. Maybe there's some way of making this generic so the context can be updated as the AST is traversed, and mapped to user defined input.